### PR TITLE
Add install of gnupg2 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN yum -y install rpm dnf-plugins-core \
       python3-pip \
       python3-pyyaml \
       iproute \
+      gnupg2 \
  && yum clean all
 
 # Upgrade pip to latest version.


### PR DESCRIPTION
Running the role [geerlingguy/ansible-role-docker](https://github.com/geerlingguy/ansible-role-docker) in a playbook I was testing would fail in this container. The failure was due to GPG2 not being installed so that Docker's GPG key could not be downloaded. Having gnupg2 be installed in the container solved my problem. 